### PR TITLE
Replace the Cli struct powered Structopt by a new one backed by Clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,17 +57,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -286,12 +301,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -606,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,12 +718,12 @@ dependencies = [
 name = "radio-cli"
 version = "2.0.0"
 dependencies = [
+ "clap",
  "colored",
  "inquire",
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "xdg",
 ]
 
@@ -916,33 +934,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -970,13 +964,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1149,12 +1149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1267,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ depends = ["mpv"]
 optdepends = ["youtube-dl"]
 
 [dependencies]
-structopt = "0.3.26"
-serde = {version="^1.0", features = ["derive"]}
+clap = { version = "3.1.15", features = ["derive", "clap_derive"] }
+serde = { version="^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", default-features = false, features = ["alloc"] }
 colored = "2"
 xdg = "2.4.1" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,76 +1,52 @@
 use std::process::{Command, Stdio};
 use std::io::{Write};
 use radio_libs::{Config, ConfigError, Station, Version, perror};
-pub use structopt::StructOpt;
 use std::path::PathBuf;
+pub use clap::Parser;
 use colored::*;
 
-pub fn help() {
-	println!(
-r#"
-{}
-	Usage: radio [OPTIONS]
-
-	Note: When playing, all the keybindings of mpv can be used, and `q` is reserved for exiting the program
-
-{}
-	-u --url <URL>: Specifies an url to be played.
-	-s --station <station name>: Specifies the name of the station to be played
-	-c --config <config file>: Specify a different config file from the default one
-	--show-video: If *not* present, a flag is passed down to mpv to not show the video and just play the audio.
-	-v --verbose: Show extra information
-	-h --help: Show this help and exit
-
-{}
-	The config file is personal and you should modify it with your own preferred stations.
-	However, if you'd like to easily update from the one on GitHub, it is as easy as deleting the config.json file (see next section).
-	The next time you launch the program, it will automatically download the file again.
-	
-	Feel free to add new stations to the GitHub config file!
-
-{}
-	The config file should be located in "$XDG_CONFIG_HOME/radio-cli/config.json". 
-	If the file does not exist (e.g.: first time you run it), the program will {} of the repository.
-	Inside this config file you can find all the stations and their URLs, feel free to add the ones you listen to,
-	and it would be awesome if you added them to the main config file too! (https://github.com/margual56/radio-cli/blob/main/config.json)
-"#, 
-	"An interactive radio player that uses mpv".bold(),
-	"OPTIONS: Used to play somethig directly".bold(),
-	"UPDATE: Update the config file".bold(),
-	"CONFIG: How to add new stations, edit and such".bold(),
-	"automatically download the one from the main branch".bold()
-	);
-}
-
-
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
+#[clap(
+    author,
+    version,
+    about,
+    long_about = "Note: When playing, all the keybindings of mpv can be used, and `q` is reserved for exiting the program"
+)]
 pub struct Cli {
-	/// Option: -u <URL>: Specifies an url to be played.
-    #[structopt(short, long)]
+    /// Option: -u <URL>: Specifies an url to be played.
+    #[clap(short, long, help = "Specifies an url to be played.")]
     url: Option<String>,
-    
-	/// Option: -s <station name>: Specifies the name of the station to be played
-    #[structopt(short, long, conflicts_with="url")]
+
+    /// Option: -s <station name>: Specifies the name of the station to be played
+    #[clap(
+        short,
+        long,
+        conflicts_with = "url",
+        help = "Specifies the name of the station to be played."
+    )]
     station: Option<String>,
-	
-    #[structopt(long="show-video")]
-	show_video: bool,
 
-    #[structopt(long, short, parse(from_os_str))]
-	config: Option<PathBuf>,
+    #[clap(
+        long = "show-video",
+        help = "If *not* present, a flag is passed down to mpv to not show the video and just play the audio."
+    )]
+    show_video: bool,
 
-	/// Show extra info
-	#[structopt(short, long)]
-	verbose: bool,
+    #[clap(
+        long,
+        short,
+        parse(from_os_str),
+        help = "Specify a different config file from the default one."
+    )]
+    config: Option<PathBuf>,
 
-	/// Show debug info
-	#[structopt(short, long)]
-	debug: bool,
+    /// Show extra info
+    #[structopt(short, long, help = "Show extra information.")]
+    verbose: bool,
 
-	/// Show the help and exit
-	#[structopt(short, long)]
-	help: bool,
-	
+    /// Show debug info
+    #[structopt(short, long)]
+    debug: bool,
 }
 
 fn main() {
@@ -83,13 +59,7 @@ fn main() {
 	};
 
     // Parse the arguments
-    let args = Cli::from_args();
-
-	// Just print the help and exit
-	if args.help {
-		help();
-		std::process::exit(0);
-	}
+    let args = Cli::parse();
 
 	// Parse the config file
 	let config_result: Result<Config, ConfigError> = match args.config {


### PR DESCRIPTION
Hi!
Great job for radio-cli, congrats! 

I like the project and I think it might be a good idea to use clap in version 3 to handle CLI things because clap::Parser does the job for you to generate a help menu and define some conditions etc... You don't even need to define a help() function or to define a `-h, --help` option because it's already included by Clap.
Clap can also read metadata from Cargo.toml to display some information. I don't know if you want to handle some environement variables so the `env` flag for clap is not present in Cargo.toml.

Also, Structopt will not receive any feature in the future, so that's why I recommend to switch on Clap especially.

> As clap v3 is now out, and the structopt features are integrated into (almost as-is), structopt is now in maintenance mode: no new feature will be added.
Bugs will be fixed, and documentation improvements will be accepted.

Extract from https://docs.rs/structopt/latest/structopt/

I suggest to format your code using `cargo fmt` in the future, if you want of course.

Thank you!
