### PR TITLE
ci(refactor_jobs): split the job into several jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,3 +89,65 @@ jobs:
 
       - name: Cargo test release
         run: cargo test --release --all-features --verbose
+
+  nightly-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Build debug
+        run: cargo build --verbose
+
+      - name: Build release
+        run: cargo build --release --verbose
+
+      - uses: actions/cache@v2
+        id: nightly-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+  nightly-tests:
+    runs-on: ubuntu-latest
+    needs: ['nightly-build']
+    steps:
+      - name: Restore cache
+        uses: actions/cache@v2
+        id: nightly-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo test debug
+        run: cargo test --all-features --verbose
+
+      - name: Cargo test release
+        run: cargo test --release --all-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   push:
     branches: [ main ]
+    tags:
+      - '*'
   pull_request:
     branches: [ main ]
 
@@ -10,13 +12,80 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  fmt:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt 
+
+      - name: Check code format
+        run: cargo fmt --all -- --check
+
+  stable-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Build debug
+        run: cargo build --verbose
+
+      - name: Build release
+        run: cargo build --release --verbose
+
+      - uses: actions/cache@v2
+        id: stable-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+  stable-tests:
+    runs-on: ubuntu-latest
+    needs: ['stable-build']
+    steps:
+      - name: Restore cache
+        uses: actions/cache@v2
+        id: stable-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo test debug
+        run: cargo test --all-features --verbose
+
+      - name: Cargo test release
+        run: cargo test --release --all-features --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,7 @@ fn main() {
                         }
                     };
 
-                    Station {
-                        station: x,
-                        url,
-                    }
+                    Station { station: x, url }
                 }
 
                 // Otherwise


### PR DESCRIPTION
Hi!

This PR brings some refactoring for the CI.

I splitted the build job into several jobs to check if the code is correctly formatted (using cargo fmt) and to build the code and run the tests (in both debug and release mode) for stable and nightly toolchain.
It's interesting to know if the code compile and run correctly in nightly to be able to handle some future deprecation with the evolution of rust.

I use an action for caching cargo artifact between some jobs. I think it should work.

Thank you!