### PR TITLE
Online radios using radio-browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,169 @@
 version = 3
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8b508d585e01084059b60f06ade4cb7415cd2e4084b71dd1cb44e7d3fb9880"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "async-io"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-process"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
+name = "async-std"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-resolver"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2f8a4a203be3325981310ab243a28e6e4ea55b6519bffce05d41ab60e09ad8"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-io",
+ "futures-util",
+ "pin-utils",
+ "socket2",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "async-task"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+
+[[package]]
+name = "async-trait"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +195,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +237,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -106,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +328,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,7 +347,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.7.14",
- "parking_lot",
+ "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -145,6 +361,22 @@ checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "dirs"
@@ -174,6 +406,24 @@ checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fastrand"
@@ -216,12 +466,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -231,10 +497,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -254,8 +557,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -271,7 +577,19 @@ checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -312,6 +630,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -431,6 +760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
+dependencies = [
+ "socket2",
+ "widestring",
+ "winapi",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,12 +830,28 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "value-bag",
 ]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -569,6 +941,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +1015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,7 +1028,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -646,6 +1053,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -673,6 +1093,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,12 +1137,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -721,10 +1166,57 @@ dependencies = [
  "clap",
  "colored",
  "inquire",
+ "radiobrowser",
  "reqwest",
  "serde",
  "serde_json",
  "xdg",
+]
+
+[[package]]
+name = "radiobrowser"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29c99c94ce2e4d9d4a54f1d3a8a5c37fc596ec94d73f1ed5f7e1005537e45d"
+dependencies = [
+ "async-std",
+ "async-std-resolver",
+ "chrono",
+ "futures",
+ "log",
+ "rand",
+ "reqwest",
+ "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -789,7 +1281,17 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.10.1",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -839,18 +1341,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -940,13 +1442,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -996,6 +1498,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1092,6 +1605,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot 0.12.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1658,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"
@@ -1125,12 +1687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1696,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
 ]
 
 [[package]]
@@ -1155,6 +1721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1253,6 +1825,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1869,58 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "radio-cli"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ colored = "2"
 xdg = "2.4.1" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html
 inquire = "0.2.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+radiobrowser = { version = "0.4.0"}
 
 [lib]
 path = "src/lib/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Marcos Gutiérrez Alonso <margual56@gmail.com>"]
 description = "A simple radio cli for listening to your favourite streams from the console"
 name = "radio-cli"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 homepage = "https://github.com/margual56/radio-cli"
 repository = "https://github.com/margual56/radio-cli"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![GitHub](https://img.shields.io/github/license/margual56/radio-cli?style=flat-square) ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/margual56/radio-cli/Rust/main?style=flat-square)
 
 # radio-cli
-A simple radio CLI written in rust
+A simple radio CLI written in rust.
+
+**NEW**: Now it can search for any radio station! Just select the "Other" option to be prompted for the search.
 
 [![asciicast](https://asciinema.org/a/ZRXVjIsGUWj6g7DyeR2V50Ge3.svg)](https://asciinema.org/a/ZRXVjIsGUWj6g7DyeR2V50Ge3?t=6)
 
@@ -14,6 +16,8 @@ To play youtube music you need to have `youtube-dl` installed!
 To use it, just type `radio-cli` after installing it and the program will guide you.
 
 When playing music, __you can use the mpv keybindings__ to control it (spacebar to play/pause, etc).
+
+You can add a country to your config (optional) and search for any radio station!
 
 # Installation
 - On Arch (and derivatives such as Manjaro), you can just install it through [the AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=radio-cli-bin) called **radio-cli-bin**. If you have an AUR helper:
@@ -41,10 +45,14 @@ The rest is thanks to the **wonderful** and **amazing** [mpv player](https://git
 
 Let's say this is just a cli frontend for playing things on mpv 😄, kinda like [ani-cli](https://github.com/pystardust/ani-cli) but without search functionalities and focused on radio stations.
 
+If the station you want was not defined in the config, you will be able to search for it!
+
 ## Configurability
-As said before, this app is just a compilation of radios. It can be found in [the config file](https://github.com/margual56/radio-cli/blob/main/config.json) as a JSON, with a list of station names and their URLs.
+As said before, this app is just a compilation of radios + a search prompt for online radios. It can be found in [the config file](https://github.com/margual56/radio-cli/blob/main/config.json) as a JSON, with a list of station names and their URLs.
 
 Of course you can add literally WHATEVER you want, even youtube videos (again, all thanks to mpv).
+
+Otherwise, you can just use the online search functionality.
 
 ## Fork me!
 If you (wrongfully xD) think mpv is not the best player, go ahead, fork me and change it :)
@@ -58,8 +66,12 @@ Don't be surprised if these are not implemented in the end hehe (if there is no 
 - [ ] Loop to selection list when pressing `q` while playing
 - [x] ~Some kind of online updating of the list of stations~ _(kind of)_
 - [x] ~Code optimizations/beautification~
+- [x] ~Search international online radios~
 - Languages:
   - [x] ~English~
   - [ ] Spanish
   - [ ] Others(?)
 - [x] ~An AUR installer~
+
+# Honorable mentions
+- A **BIG** thank you to the amazing developer/s of [Radio Browser](https://www.radio-browser.info/) and its wonderful [API](http://api.radio-browser.info/) and [rust library](https://crates.io/crates/radiobrowser). 

--- a/config.json
+++ b/config.json
@@ -3,26 +3,6 @@
 	"max_lines": 7,
 	"data": [
 		{
-			"station": "Los 40 Principales",
-			"url": "https://20043.live.streamtheworld.com/LOS40AAC.aac"
-		},
-		{
-			"station": "Europa FM",
-			"url": "https://livefastly-webs.europafm.com/europafm/audio/chunklist.m3u8"
-		},
-		{
-			"station": "Kiss FM",
-			"url": "https://kissfm.kissfmradio.cires21.com/kissfm.mp3"
-		},
-		{
-			"station": "Cadena SER",
-			"url": "https://22333.live.streamtheworld.com/CADENASERAAC_SC?dist=onlineradiobox"
-		},
-		{
-			"station": "Rock FM",
-			"url": "https://rockfm-cope.flumotion.com/chunks.m3u8"
-		},
-		{
 			"station": "lofi",
 			"url": "https://www.youtube.com/watch?v=5qap5aO4i9A"
 		}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
 	"config_version": "2.1.0",
 	"max_lines": 7,
+	"country": "ES",
 	"data": [
 		{
 			"station": "lofi",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"config_version": "2.0.1",
+	"config_version": "2.1.0",
 	"max_lines": 7,
 	"data": [
 		{

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -1,6 +1,17 @@
+use std::error::Error;
+
 use crate::{station::Station, Config};
 use inquire::{error::InquireError, Text};
-use radiobrowser::{blocking::RadioBrowserAPI, StationOrder};
+use radiobrowser::{blocking::RadioBrowserAPI, ApiCountry, StationOrder};
+
+pub fn get_countries() -> Result<Vec<ApiCountry>, Box<dyn Error>> {
+    let api = match RadioBrowserAPI::new() {
+        Ok(r) => r,
+        Err(_e) => panic!("Failed to create Radio Browser API!"),
+    };
+
+    api.get_countries().send()
+}
 
 pub fn get_station(name: String, country_code: &str) -> Result<Station, InquireError> {
     let api = match RadioBrowserAPI::new() {

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -13,35 +13,45 @@ pub fn get_countries() -> Result<Vec<ApiCountry>, Box<dyn Error>> {
     api.get_countries().send()
 }
 
-pub fn get_station(name: String, country_code: &str) -> Result<Station, InquireError> {
+pub fn get_station(name: String, country_code: Option<String>) -> Result<Station, InquireError> {
     let api = match RadioBrowserAPI::new() {
         Ok(r) => r,
         Err(_e) => panic!("Failed to create Radio Browser API!"),
     };
 
-    match api
-        .get_stations()
-        .name(name)
-        .countrycode(country_code)
-        .send()
-    {
-        Ok(s) => match s.get(0) {
-            Some(x) => Ok(Station {
-                station: x.name.clone(),
-                url: x.url.clone(),
-            }),
-            None => Err(InquireError::InvalidConfiguration(
-                "Radio station does not exist".to_string(),
-            )),
-        },
-        Err(_e) => Err(InquireError::OperationInterrupted),
+    if let Some(code) = country_code {
+        return match api.get_stations().name(name).countrycode(code).send() {
+            Ok(s) => match s.get(0) {
+                Some(x) => Ok(Station {
+                    station: x.name.clone(),
+                    url: x.url.clone(),
+                }),
+                None => Err(InquireError::InvalidConfiguration(
+                    "Radio station does not exist".to_string(),
+                )),
+            },
+            Err(_e) => Err(InquireError::OperationInterrupted),
+        };
+    } else {
+        return match api.get_stations().name(name).send() {
+            Ok(s) => match s.get(0) {
+                Some(x) => Ok(Station {
+                    station: x.name.clone(),
+                    url: x.url.clone(),
+                }),
+                None => Err(InquireError::InvalidConfiguration(
+                    "Radio station does not exist".to_string(),
+                )),
+            },
+            Err(_e) => Err(InquireError::OperationInterrupted),
+        };
     }
 }
 
 fn search_station(
     message: &str,
     placeholder: &str,
-    country_code: &str,
+    country_code: Option<String>,
 ) -> Result<String, InquireError> {
     let api = match RadioBrowserAPI::new() {
         Ok(r) => r,
@@ -52,18 +62,33 @@ fn search_station(
         .with_placeholder(placeholder)
         .with_suggester(&|s: &str| {
             if s.len() > 3 {
-                match api
-                    .get_stations()
-                    .countrycode(country_code)
-                    .name(s)
-                    .order(StationOrder::Clickcount)
-                    .send()
-                {
-                    Ok(s) => s
-                        .iter()
-                        .map(|station| String::from(&station.name))
-                        .collect(),
-                    Err(_e) => Vec::new(),
+                if let Some(code) = &country_code {
+                    match api
+                        .get_stations()
+                        .countrycode(code)
+                        .name(s)
+                        .order(StationOrder::Clickcount)
+                        .send()
+                    {
+                        Ok(s) => s
+                            .iter()
+                            .map(|station| String::from(&station.name))
+                            .collect(),
+                        Err(_e) => Vec::new(),
+                    }
+                } else {
+                    match api
+                        .get_stations()
+                        .name(s)
+                        .order(StationOrder::Clickcount)
+                        .send()
+                    {
+                        Ok(s) => s
+                            .iter()
+                            .map(|station| String::from(&station.name))
+                            .collect(),
+                        Err(_e) => Vec::new(),
+                    }
                 }
             } else {
                 Vec::new()
@@ -76,11 +101,11 @@ pub fn prompt(config: Config) -> Result<Station, InquireError> {
     let station = search_station(
         "Search for a station: ",
         "Station name",
-        &config.country_code.clone(),
+        config.country_code.clone(),
     );
 
     match station {
-        Ok(s) => get_station(s, &config.country_code.clone()),
+        Ok(s) => get_station(s, config.country_code.clone()),
         Err(e) => Err(e),
     }
 }

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -2,7 +2,7 @@ use crate::station::Station;
 use inquire::{error::InquireError, Text};
 use radiobrowser::{blocking::RadioBrowserAPI, StationOrder};
 
-fn get_station(name: String) -> Result<Station, InquireError> {
+pub fn get_station(name: String) -> Result<Station, InquireError> {
     let api = match RadioBrowserAPI::new() {
         Ok(r) => r,
         Err(_e) => panic!("Failed to create Radio Browser API!"),
@@ -35,17 +35,24 @@ fn search_station(message: &str, placeholder: &str) -> Result<String, InquireErr
 
     Text::new(message)
         .with_placeholder(placeholder)
-        .with_suggester(&|s: &str| match api
-            .get_stations()
-            .name(s)
-            .order(StationOrder::Clickcount)
-            .send()
-        {
-            Ok(s) => s
-                .iter()
-                .map(|station| String::from(&station.name))
-                .collect(),
-            Err(_e) => Vec::new(),
+        .with_suggester(&|s: &str| {
+            if s.len() > 3 {
+                match api
+                    .get_stations()
+                    .countrycode("ES")
+                    .name(s)
+                    .order(StationOrder::Clickcount)
+                    .send()
+                {
+                    Ok(s) => s
+                        .iter()
+                        .map(|station| String::from(&station.name))
+                        .collect(),
+                    Err(_e) => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            }
         })
         .prompt()
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
 
     #[serde(alias = "country")]
     pub country_code: String,
-    
+
     pub data: Vec<Station>,
 }
 
@@ -157,17 +157,17 @@ impl Config {
     pub fn prompt(self) -> Result<Station, InquireError> {
         let res: Result<Station, InquireError>;
         if let Some(lines) = self.max_lines {
-            res = Select::new(&"Select a station to play:".bold(), self.data)
+            res = Select::new(&"Select a station to play:".bold(), self.data.clone())
                 .with_page_size(lines)
                 .prompt();
         } else {
-            res = Select::new(&"Select a station to play:".bold(), self.data).prompt();
+            res = Select::new(&"Select a station to play:".bold(), self.data.clone()).prompt();
         }
 
         let station: Station = match res {
             Ok(s) => {
                 if s.station.eq("Other") {
-                    match browser::prompt() {
+                    match browser::prompt(self) {
                         Ok(r) => r,
                         Err(e) => return Err(e),
                     }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::radiobrowser;
+use crate::browser;
 
 const _CONFIG_URL: &str = "https://raw.githubusercontent.com/margual56/radio-cli/main/config.json";
 
@@ -23,6 +23,10 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_version")]
     pub config_version: Version,
     pub max_lines: Option<usize>,
+
+    #[serde(alias = "country")]
+    pub country_code: String,
+    
     pub data: Vec<Station>,
 }
 
@@ -163,7 +167,7 @@ impl Config {
         let station: Station = match res {
             Ok(s) => {
                 if s.station.eq("Other") {
-                    match radiobrowser::prompt() {
+                    match browser::prompt() {
                         Ok(r) => r,
                         Err(e) => return Err(e),
                     }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -25,7 +25,7 @@ pub struct Config {
     pub max_lines: Option<usize>,
 
     #[serde(alias = "country")]
-    pub country_code: String,
+    pub country_code: Option<String>,
 
     pub data: Vec<Station>,
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,6 +1,6 @@
 mod config;
 mod errors;
-mod radiobrowser;
+mod browser;
 mod station;
 mod version;
 
@@ -8,6 +8,7 @@ pub use config::Config;
 pub use errors::{ConfigError, ConfigErrorCode};
 pub use station::Station;
 pub use version::Version;
+pub use browser::get_station;
 
 use colored::*;
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,10 +1,9 @@
-mod browser;
+pub mod browser;
 mod config;
 mod errors;
 mod station;
 mod version;
 
-pub use browser::get_station;
 pub use config::Config;
 pub use errors::{ConfigError, ConfigErrorCode};
 pub use station::Station;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod errors;
+mod radiobrowser;
 mod station;
 mod version;
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,14 +1,14 @@
+mod browser;
 mod config;
 mod errors;
-mod browser;
 mod station;
 mod version;
 
+pub use browser::get_station;
 pub use config::Config;
 pub use errors::{ConfigError, ConfigErrorCode};
 pub use station::Station;
 pub use version::Version;
-pub use browser::get_station;
 
 use colored::*;
 

--- a/src/lib/radiobrowser.rs
+++ b/src/lib/radiobrowser.rs
@@ -1,0 +1,60 @@
+use crate::station::Station;
+use inquire::{error::InquireError, Text};
+use radiobrowser::{blocking::RadioBrowserAPI, StationOrder};
+
+fn get_station(name: String) -> Result<Station, InquireError> {
+    let api = match RadioBrowserAPI::new() {
+        Ok(r) => r,
+        Err(_e) => panic!("Failed to create Radio Browser API!"),
+    };
+
+    match api
+        .get_stations()
+        .name(name)
+        .order(StationOrder::Clickcount)
+        .send()
+    {
+        Ok(s) => match s.get(0) {
+            Some(x) => Ok(Station {
+                station: x.name.clone(),
+                url: x.url.clone(),
+            }),
+            None => Err(InquireError::InvalidConfiguration(
+                "Radio station does not exist".to_string(),
+            )),
+        },
+        Err(_e) => Err(InquireError::OperationInterrupted),
+    }
+}
+
+fn search_station(message: &str, placeholder: &str) -> Result<String, InquireError> {
+    let api = match RadioBrowserAPI::new() {
+        Ok(r) => r,
+        Err(_e) => panic!("Failed to create Radio Browser API!"),
+    };
+
+    Text::new(message)
+        .with_placeholder(placeholder)
+        .with_suggester(&|s: &str| match api
+            .get_stations()
+            .name(s)
+            .order(StationOrder::Clickcount)
+            .send()
+        {
+            Ok(s) => s
+                .iter()
+                .map(|station| String::from(&station.name))
+                .collect(),
+            Err(_e) => Vec::new(),
+        })
+        .prompt()
+}
+
+pub fn prompt() -> Result<Station, InquireError> {
+    let station = search_station("Search for a station: ", "Station name");
+
+    match station {
+        Ok(s) => get_station(s),
+        Err(e) => Err(e),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,12 @@ fn main() {
     if let None = config.country_code {
         println!("\n{} {}", "Warning!".yellow().bold(), 
 		"The config does not contain a valid country (for example, \"ES\" for Spain or \"US\" for the US).".italic());
-        println!("{} {} {}\n", "You can use the option".italic(), "--list-countries".bold().italic(), "to see the available options".italic());
+        println!(
+            "{} {} {}\n",
+            "You can use the option".italic(),
+            "--list-countries".bold().italic(),
+            "to see the available options.".italic()
+        );
         println!(
             "{}",
             "No country filter will be used, so searches could be slower and less accurate."

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
     let config = match config_result {
         Ok(mut x) => {
             if let Some(cc) = args.country_code {
-                x.country_code = cc;
+                x.country_code = Some(cc);
             }
 
             x
@@ -143,9 +143,10 @@ fn main() {
 		"The config version does not match the program version.\nThis might lead to parsing errors.".italic())
     }
 
-    if config.country_code.len() != 2 {
-        println!("\n{} {}\n", "Warning!".yellow().bold(), 
+    if let None = config.country_code {
+        println!("\n{} {}", "Warning!".yellow().bold(), 
 		"The config does not contain a valid country (for example, \"ES\" for Spain or \"US\" for the US).".italic());
+        println!("{} {} {}\n", "You can use the option".italic(), "--list-countries".bold().italic(), "to see the available options".italic());
         println!(
             "{}",
             "No country filter will be used, so searches could be slower and less accurate."
@@ -171,7 +172,7 @@ fn main() {
 
                             internet = true;
 
-                            match browser::get_station(x.clone(), &config.country_code.clone()) {
+                            match browser::get_station(x.clone(), config.country_code.clone()) {
                                 Ok(s) => s.url,
                                 Err(e) => {
                                     perror("This station was not found :(");

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ fn main() {
         );
     }
 
+    let mut internet = false;
     let station = match args.url {
         None => {
             let station: Station = match args.station {
@@ -167,6 +168,8 @@ fn main() {
                                     .yellow()
                                     .italic()
                             );
+
+                            internet = true;
 
                             match browser::get_station(x.clone(), &config.country_code.clone()) {
                                 Ok(s) => s.url,
@@ -204,7 +207,13 @@ fn main() {
                 }
             };
 
-            println!("Playing {}", station.station.green());
+            print!("Playing {}", station.station.green());
+
+            if internet {
+                println!(" ({})", station.url.yellow().italic());
+            } else {
+                println!();
+            }
 
             station
         }


### PR DESCRIPTION
## Summary
This pull request adds the option to search for online radios using the amazing radio-browser API. It closes #12 (check it out for more details).

## Details
The idea is to have a list of user-defined stations, and then "Others". If you select others, another prompt will pop up and let you type the station name. Suggestions of your search will start to show and you will be able to select one and start listening.

It won't show any result until you type at least 3 characters.

This is a limitation too, because I'm sure there's a one-letter radio station somewhere in the world... But for those cases, I added functionality to the `-s --station <station name>` option. It now looks for the station in the config file, and if it does not find a match, it will request the station to radio-browser.

As a small optimization, I also added a country_code to the config file (and as an optional argument) because most people will only listen to one country's stations. And if you want a specific one temporarily, you can just use the flag `--country-code <code>` and it will use that one.

Finally, I am implementing a flag that will list all the available country codes so you can find yours and add it to the config.

## Objectives
- [x] Online radio search prompt
- [x] Filter by country from the config
- [x] Optional argument for specifying the country
- [x] Implement online search for the `-s` flag
- [x] Prioritize results from the local config 
- [x] List available country codes
- [x] Show station name and url so it can be manually added to the config
- [x] Increment version number