### PR TITLE
Library Updates and Forked Radiobrowser Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,13 +12,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -109,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -128,7 +137,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -138,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "async-std-resolver"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2f8a4a203be3325981310ab243a28e6e4ea55b6519bffce05d41ab60e09ad8"
+checksum = "6ba50e24d9ee0a8950d3d03fc6d0dd10aa14b5de3b101949b4e160f7fee7c723"
 dependencies = [
  "async-std",
  "async-trait",
@@ -165,7 +173,7 @@ checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -193,9 +201,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -249,15 +257,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -296,7 +306,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -306,6 +316,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -386,7 +406,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.11",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -432,14 +496,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -524,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -539,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -549,15 +613,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -566,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -587,32 +651,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -787,6 +851,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6055ce38cac9b10ac819ed4a509d92ccbc60808152c19ff9121c98198964272"
+checksum = "fd079157ad94a32f7511b2e13037f3ae417ad80a6a9b0de29154d48b86f5d6c8"
 dependencies = [
  "bitflags",
  "crossterm",
@@ -907,6 +995,15 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1183,7 +1280,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
  "version_check",
 ]
 
@@ -1200,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -1215,9 +1312,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1241,9 +1338,8 @@ dependencies = [
 
 [[package]]
 name = "radiobrowser"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29c99c94ce2e4d9d4a54f1d3a8a5c37fc596ec94d73f1ed5f7e1005537e45d"
+version = "0.4.1"
+source = "git+https://gitlab.com/margual56/radiobrowser-lib-rust.git#aa24e6bf8a6a1304286c1fb702f1978cc532a1dd"
 dependencies = [
  "async-std",
  "async-std-resolver",
@@ -1333,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64",
  "bytes",
@@ -1349,10 +1445,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -1360,6 +1456,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1414,6 +1511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
 name = "security-framework"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,22 +1541,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1549,6 +1652,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1702,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -1683,7 +1797,7 @@ checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
 ]
 
 [[package]]
@@ -1697,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1711,30 +1825,30 @@ dependencies = [
  "idna",
  "ipnet",
  "lazy_static",
- "log",
  "rand",
  "smallvec",
  "thiserror",
  "tinyvec",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log",
  "lru-cache",
  "parking_lot",
  "resolv-conf",
  "smallvec",
  "thiserror",
+ "tracing",
  "trust-dns-proto",
 ]
 
@@ -1860,7 +1974,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -1894,7 +2008,7 @@ checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "radio-cli"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,7 +180,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -265,6 +274,16 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2b6c3dcdb73299f48ae05b294da14e2f560b3ed2c09e742269eb1b22af231"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]
@@ -421,6 +440,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -637,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +742,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -765,6 +833,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +859,18 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itoa"
@@ -814,15 +904,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lock_api"
@@ -957,7 +1053,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1032,7 +1128,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1131,8 +1227,11 @@ name = "radio-cli"
 version = "2.1.2"
 dependencies = [
  "clap",
+ "clap-verbosity-flag",
  "colored",
+ "env_logger",
  "inquire",
+ "log",
  "radiobrowser",
  "reqwest",
  "serde",
@@ -1207,6 +1306,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1375,20 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1837,12 +1967,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1851,10 +2002,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1863,16 +2026,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,26 +254,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -284,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -339,15 +337,15 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
+ "mio",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -355,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
@@ -397,6 +395,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "encoding_rs"
@@ -737,12 +741,13 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.2.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2660dd0494633c5d60afe445e54fc5486a9a628d0ae58ee9e09cd42b6e976500"
+checksum = "e6055ce38cac9b10ac819ed4a509d92ccbc60808152c19ff9121c98198964272"
 dependencies = [
  "bitflags",
  "crossterm",
+ "dyn-clone",
  "lazy_static",
  "newline-converter",
  "thiserror",
@@ -873,19 +878,6 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
@@ -971,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
@@ -1022,37 +1014,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1137,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1394,12 +1361,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
+ "mio",
  "signal-hook",
 ]
 
@@ -1475,12 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,7 +1496,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
@@ -1640,7 +1601,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot",
  "resolv-conf",
  "smallvec",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,16 @@ depends = ["mpv"]
 optdepends = ["youtube-dl"]
 
 [dependencies]
-clap = { version = "3.1.15", features = ["derive", "clap_derive"] }
-serde = { version="^1.0", features = ["derive"] }
-serde_json = { version = "^1.0", default-features = false, features = ["alloc"] }
-colored = "2"
-xdg = "2.4.1" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html
-inquire = "0.2.1"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-radiobrowser = { version = "0.4.0"}
+clap = { version = "^4", features = ["derive", "clap_derive"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1.0", default-features = false, features = [
+    "alloc",
+] }
+colored = "^2"
+xdg = "^2.4" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html
+inquire = "^0.5"
+reqwest = { version = "^0.11", features = ["blocking", "json"] }
+radiobrowser = { version = "^0.4" }
 
 [lib]
 path = "src/lib/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ xdg = "^2.4" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html
 inquire = "^0.5"
 reqwest = { version = "^0.11", features = ["blocking", "json"] }
 radiobrowser = { version = "^0.4" }
+clap-verbosity-flag = "2.0.0"
+env_logger = "0.10.0"
+log = "0.4.17"
 
 [lib]
 path = "src/lib/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ serde_json = { version = "^1.0", default-features = false, features = [
 ] }
 colored = "^2"
 xdg = "^2.4" # https://docs.rs/xdg/latest/xdg/struct.BaseDirectories.html
-inquire = "^0.5"
+inquire = "0.6.0"
 reqwest = { version = "^0.11", features = ["blocking", "json"] }
-radiobrowser = { version = "^0.4" }
+radiobrowser = { git = "https://gitlab.com/margual56/radiobrowser-lib-rust.git" }
 clap-verbosity-flag = "2.0.0"
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Marcos Gutiérrez Alonso <margual56@gmail.com>"]
 description = "A simple radio cli for listening to your favourite streams from the console"
 name = "radio-cli"
-version = "2.1.2"
+version = "2.2.0"
 edition = "2021"
 homepage = "https://github.com/margual56/radio-cli"
 repository = "https://github.com/margual56/radio-cli"

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::{station::Station, Config};
-use inquire::{error::InquireError, Text, Autocomplete};
+use inquire::{error::InquireError, Autocomplete, Text};
 use radiobrowser::{blocking::RadioBrowserAPI, ApiCountry, ApiStation, StationOrder};
 
 #[derive(Debug, Clone)]
@@ -35,7 +35,7 @@ impl Autocomplete for Stations {
             None => Err(inquire::CustomUserError::from("No suggestion available")),
         }
     }
-}    
+}
 
 pub struct Browser {
     api: RadioBrowserAPI,

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -88,13 +88,15 @@ impl Browser {
 
         Text::new(message)
             .with_placeholder(placeholder)
-            .with_suggester(&|s: &str| {
-                self.stations
-                    .iter()
-                    .filter(|station| station.name.contains(s) || station.tags.contains(s))
-                    .map(|station| String::from(&station.name))
-                    .collect()
-            })
+            // Deprecated: need to change to `with_autosuggester`
+            // But for that, ApiStation needs to implement the Clone trait
+            // .with_suggester(&|s: &str| {
+            //     self.stations
+            //         .iter()
+            //         .filter(|station| station.name.contains(s) || station.tags.contains(s))
+            //         .map(|station| String::from(&station.name))
+            //         .collect()
+            // })
             .with_page_size(max_lines)
             .prompt()
     }

--- a/src/lib/cli_args.rs
+++ b/src/lib/cli_args.rs
@@ -1,0 +1,61 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug, Clone)]
+#[clap(
+    author,
+    version,
+    about,
+    long_about = "Note: When playing, all the keybindings of mpv can be used, and `q` is reserved for exiting the program"
+)]
+pub struct Cli {
+    /// Option: -u --url <URL>: Specifies an url to be played.
+    #[clap(short, long, help = "Specifies an url to be played.")]
+    pub url: Option<String>,
+
+    /// Option: -s --station <station name>: Specifies the name of the station to be played
+    #[clap(
+        short,
+        long,
+        conflicts_with = "url",
+        help = "Specifies the name of the station to be played."
+    )]
+    pub station: Option<String>,
+
+    /// Flag: --show-video: If *not* present, a flag is passed down to mpv to not show the video and just play the audio.
+    #[clap(
+        long = "show-video",
+        help = "If *not* present, a flag is passed down to mpv to not show the video and just play the audio."
+    )]
+    pub show_video: bool,
+
+    /// Option: -c --config: Specify a config file other than the default.
+    #[clap(
+        long,
+        short,
+        help = "Specify a different config file from the default one."
+    )]
+    pub config: Option<PathBuf>,
+
+    /// Option: --country-code <CODE>: Specify a country code to filter the search results
+    #[clap(
+        long = "country-code",
+        help = "Specify a country code to filter the search."
+    )]
+    pub country_code: Option<String>,
+
+    /// Flag: --list-countries: List all the available countries and country codes to put in the config.
+    #[clap(
+        long = "list-countries",
+        help = "List all the available countries and country codes to put in the config."
+    )]
+    pub list_countries: bool,
+
+    /// Show extra info
+    #[structopt(short, long, help = "Show extra information.")]
+    pub verbose: bool,
+
+    /// Show debug info
+    #[structopt(short, long)]
+    pub debug: bool,
+}

--- a/src/lib/cli_args.rs
+++ b/src/lib/cli_args.rs
@@ -52,8 +52,8 @@ pub struct Cli {
     pub list_countries: bool,
 
     /// Show extra info
-    #[structopt(short, long, help = "Show extra information.")]
-    pub verbose: bool,
+    #[clap(flatten)]
+    pub verbose: clap_verbosity_flag::Verbosity,
 
     /// Show debug info
     #[structopt(short, long)]

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,9 +1,11 @@
 pub mod browser;
+mod cli_args;
 mod config;
 mod errors;
 mod station;
 mod version;
 
+pub use cli_args::Cli;
 pub use config::Config;
 pub use errors::{ConfigError, ConfigErrorCode};
 pub use station::Station;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,69 +1,8 @@
-pub use clap::Parser;
+use clap::Parser;
 use colored::*;
-use radio_libs::browser::Browser;
-use radio_libs::{perror, Config, ConfigError, Station, Version};
+use radio_libs::{browser::Browser, perror, Cli, Config, ConfigError, Station, Version};
 use std::io::Write;
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
-
-#[derive(Parser, Debug)]
-#[clap(
-    author,
-    version,
-    about,
-    long_about = "Note: When playing, all the keybindings of mpv can be used, and `q` is reserved for exiting the program"
-)]
-pub struct Cli {
-    /// Option: -u --url <URL>: Specifies an url to be played.
-    #[clap(short, long, help = "Specifies an url to be played.")]
-    url: Option<String>,
-
-    /// Option: -s --station <station name>: Specifies the name of the station to be played
-    #[clap(
-        short,
-        long,
-        conflicts_with = "url",
-        help = "Specifies the name of the station to be played."
-    )]
-    station: Option<String>,
-
-    /// Flag: --show-video: If *not* present, a flag is passed down to mpv to not show the video and just play the audio.
-    #[clap(
-        long = "show-video",
-        help = "If *not* present, a flag is passed down to mpv to not show the video and just play the audio."
-    )]
-    show_video: bool,
-
-    /// Option: -c --config: Specify a config file other than the default.
-    #[clap(
-        long,
-        short,
-        help = "Specify a different config file from the default one."
-    )]
-    config: Option<PathBuf>,
-
-    /// Option: --country-code <CODE>: Specify a country code to filter the search results
-    #[clap(
-        long = "country-code",
-        help = "Specify a country code to filter the search."
-    )]
-    country_code: Option<String>,
-
-    /// Flag: --list-countries: List all the available countries and country codes to put in the config.
-    #[clap(
-        long = "list-countries",
-        help = "List all the available countries and country codes to put in the config."
-    )]
-    list_countries: bool,
-
-    /// Show extra info
-    #[structopt(short, long, help = "Show extra information.")]
-    verbose: bool,
-
-    /// Show debug info
-    #[structopt(short, long)]
-    debug: bool,
-}
 
 fn main() {
     let version = match Version::from(String::from(env!("CARGO_PKG_VERSION"))) {
@@ -157,75 +96,9 @@ fn main() {
         );
     }
 
-    let mut internet = false;
     let station = match args.url {
         None => {
-            let station: Station = match args.station {
-                // If the station name is passed as an argument:
-                Some(x) => {
-                    let url = match config.clone().get_url_for(&x) {
-                        Some(u) => u,
-                        None => {
-                            println!(
-                                "{}",
-                                "Station not found in local config, searching on the internet..."
-                                    .yellow()
-                                    .italic()
-                            );
-
-                            internet = true;
-
-                            let brows = match Browser::new(config) {
-                                Ok(b) => b,
-                                Err(e) => {
-                                    perror("Could not connect with the API");
-
-                                    if args.debug {
-                                        println!("{}", e);
-                                    }
-
-                                    std::process::exit(1);
-                                }
-                            };
-
-                            match brows.get_station(x.clone()) {
-                                Ok(s) => s.url,
-                                Err(e) => {
-                                    perror("This station was not found :(");
-
-                                    if args.debug {
-                                        println!("{}", e);
-                                    }
-
-                                    std::process::exit(1);
-                                }
-                            }
-                        }
-                    };
-
-                    Station { station: x, url }
-                }
-
-                // Otherwise
-                None => {
-                    // And let the user choose one
-                    match config.clone().prompt() {
-                        Ok((s, b)) => {
-                            internet = b;
-                            s
-                        }
-                        Err(error) => {
-                            println!("\n\t{}", "Bye!".bold().green());
-
-                            if args.verbose {
-                                println!("({:?})", error);
-                            }
-
-                            std::process::exit(0);
-                        }
-                    }
-                }
-            };
+            let (station, internet) = get_station(args.station, args.verbose, args.debug, config);
 
             print!("Playing {}", station.station.green());
 
@@ -250,14 +123,32 @@ fn main() {
 
     println!("{}", "Info: press 'q' to exit".italic().bright_black());
 
+    let output_status = run_mpv(station, args.show_video, args.verbose);
+
+    if !output_status.success() {
+        perror(format!("mpv {}", output_status).as_str());
+
+        if !args.verbose {
+            println!(
+                "{}: {}",
+                "Hint".italic().bold(),
+                "Try running radio-cli with the verbose flag (-v or --verbose)".italic()
+            );
+        }
+
+        std::process::exit(2);
+    }
+}
+
+fn run_mpv(station: Station, show_video: bool, verbose: bool) -> std::process::ExitStatus {
     let mut mpv = Command::new("mpv");
     let mut mpv_args: Vec<String> = [station.url].to_vec();
 
-    if !args.show_video {
+    if !show_video {
         mpv_args.push(String::from("--no-video"));
     }
 
-    if !args.verbose {
+    if !verbose {
         mpv_args.push(String::from("--really-quiet"));
     }
 
@@ -271,17 +162,84 @@ fn main() {
     std::io::stdout().write_all(&output.stdout).unwrap();
     std::io::stderr().write_all(&output.stderr).unwrap();
 
-    if !output.status.success() {
-        perror(format!("mpv {}", output.status).as_str());
+    output.status
+}
 
-        if !args.verbose {
-            println!(
-                "{}: {}",
-                "Hint".italic().bold(),
-                "Try running radio-cli with the verbose flag (-v or --verbose)".italic()
-            );
+fn get_station(
+    station: Option<String>,
+    verbose: bool,
+    debug: bool,
+    config: Config,
+) -> (Station, bool) {
+    let mut internet = false;
+
+    match station {
+        // If the station name is passed as an argument:
+        Some(x) => {
+            let url = match config.clone().get_url_for(&x) {
+                Some(u) => u,
+                None => {
+                    println!(
+                        "{}",
+                        "Station not found in local config, searching on the internet..."
+                            .yellow()
+                            .italic()
+                    );
+
+                    internet = true;
+
+                    let brows = match Browser::new(config) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            perror("Could not connect with the API");
+
+                            if debug {
+                                println!("{}", e);
+                            }
+
+                            std::process::exit(1);
+                        }
+                    };
+
+                    match brows.get_station(x.clone()) {
+                        Ok(s) => s.url,
+                        Err(e) => {
+                            perror("This station was not found :(");
+
+                            if debug {
+                                println!("{}", e);
+                            }
+
+                            std::process::exit(1);
+                        }
+                    }
+                }
+            };
+
+            (
+                Station {
+                    station: String::from(x),
+                    url,
+                },
+                internet,
+            )
         }
 
-        std::process::exit(2);
+        // Otherwise
+        None => {
+            // And let the user choose one
+            match config.clone().prompt() {
+                Ok((s, b)) => (s, b),
+                Err(error) => {
+                    println!("\n\t{}", "Bye!".bold().green());
+
+                    if verbose {
+                        println!("({:?})", error);
+                    }
+
+                    std::process::exit(0);
+                }
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,11 +158,16 @@ fn run_mpv(station: Station, show_video: bool) -> std::process::ExitStatus {
         .output()
         .expect("Failed to execute command");
 
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
+    if !output.status.success() {
+        eprintln!("mpv error: {:?}", output.status);
+        std::io::stderr().write_all(&output.stderr).unwrap();
+    } else {
+        std::io::stdout().write_all(&output.stdout).unwrap();
+    }
 
     output.status
 }
+
 
 fn get_station(station: Option<String>, config: Config) -> (Station, bool) {
     let mut internet = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,6 @@ fn run_mpv(station: Station, show_video: bool) -> std::process::ExitStatus {
     output.status
 }
 
-
 fn get_station(station: Option<String>, config: Config) -> (Station, bool) {
     let mut internet = false;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ pub struct Cli {
     #[clap(
         long,
         short,
-        parse(from_os_str),
         help = "Specify a different config file from the default one."
     )]
     config: Option<PathBuf>,


### PR DESCRIPTION
We have upgraded all dependencies to their latest versions and switched from the original [radiobrowser](https://crates.io/crates/radiobrowser) crate to a customized fork ([radiobrowser](https://gitlab.com/margual56/radiobrowser-lib-rust)) to accommodate necessary changes.

The reason behind this modification lies in the unresponsiveness of the original library's author to [our submitted PR](https://gitlab.com/radiobrowser/radiobrowser-lib-rust/-/merge_requests/1), which aimed to introduce essential `Clone` traits for certain structs. In the absence of their acknowledgement, we opted to create and utilize our own fork.

Please be assured that these updates will not impact the final product's functionality or performance.

This update also addresses multiple security vulnerabilities detected in various packages. These vulnerabilities include:

- `openssl` `X509Extension::new` and `X509Extension::new_nid` null pointer dereference (High)
- `openssl` `SubjectAlternativeName` and `ExtendedKeyUsage::other` allow arbitrary file read (High)
- `openssl` `X509NameBuilder::build` returned object is not thread safe (Moderate)
- `bumpalo` has use-after-free due to a lifetime error in `Vec::into_iter()` (Moderate)
- `Tokio` `reject_remote_clients` configuration may get dropped when creating a Windows named pipe (Moderate)
- Segmentation fault in `time` (Moderate)
- Race Condition Enabling Link Following and Time-of-check Time-of-use (TOCTOU) Race Condition in `remove_dir_all` (Low)
- `tokio::io::ReadHalf<T>::unsplit` is Unsound (Low)

These vulnerabilities were detected in the following packages: `openssl`, `bumpalo`, `Tokio`, `time`, and `remove_dir_all`. With this update, these vulnerabilities should have been addressed and resolved.