### PR TITLE
Update URL of default lofi station

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
 	"data": [
 		{
 			"station": "lofi",
-			"url": "https://www.youtube.com/watch?v=5qap5aO4i9A"
+			"url": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
 		}
 	]
 }


### PR DESCRIPTION
The old URL does not work anymore. I replaced it with the URL of the current lofi stream.