### PR TITLE
Loop to selection list when pressing q while playing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "radio-cli"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Marcos Gutiérrez Alonso <margual56@gmail.com>"]
 description = "A simple radio cli for listening to your favourite streams from the console"
 name = "radio-cli"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2021"
 homepage = "https://github.com/margual56/radio-cli"
 repository = "https://github.com/margual56/radio-cli"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The license is GPLv2
 Don't be surprised if these are not implemented in the end hehe (if there is no interest in the project, certainly not)
 
 - [x] ~Audio (mpv) controls when not in verbose mode~
-- [ ] Loop to selection list when pressing `q` while playing
+- [x] Loop to selection list when pressing `q` while playing
 - [x] ~Some kind of online updating of the list of stations~ _(kind of)_
 - [x] ~Code optimizations/beautification~
 - [x] ~Search international online radios~

--- a/src/lib/browser.rs
+++ b/src/lib/browser.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::rc::Rc;
 
 use crate::{station::Station, Config};
 use inquire::{error::InquireError, Autocomplete, Text};
@@ -39,12 +40,12 @@ impl Autocomplete for Stations {
 
 pub struct Browser {
     api: RadioBrowserAPI,
-    config: Config,
+    config: Rc<Config>,
     stations: Vec<ApiStation>,
 }
 
 impl Browser {
-    pub fn new(config: Config) -> Result<Browser, Box<dyn Error>> {
+    pub fn new(config: Rc<Config>) -> Result<Browser, Box<dyn Error>> {
         let api = match RadioBrowserAPI::new() {
             Ok(r) => r,
             Err(e) => return Err(e),

--- a/src/lib/cli_args.rs
+++ b/src/lib/cli_args.rs
@@ -51,6 +51,13 @@ pub struct Cli {
     )]
     pub list_countries: bool,
 
+    /// Flag: --no-station-cache: Don't cache the station list loaded from the internet.
+    #[clap(
+        long = "no-station-cache",
+        help = "Don't cache the station list loaded from the internet."
+    )]
+    pub no_station_cache: bool,
+
     /// Show extra info
     #[clap(flatten)]
     pub verbose: clap_verbosity_flag::Verbosity,

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -6,15 +6,12 @@ use crate::station::Station;
 use crate::version::Version;
 
 use colored::*;
-use inquire::{error::InquireError, Select};
 use serde::de::{Deserializer, Error as SeError, Visitor};
 use serde::Deserialize;
 use std::fmt::{Formatter, Result as ResultFmt};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-
-use crate::browser::Browser;
 
 const _CONFIG_URL: &str = "https://raw.githubusercontent.com/margual56/radio-cli/main/config.json";
 
@@ -134,7 +131,7 @@ impl Config {
         }
     }
 
-    pub fn get_url_for(self, station_name: &str) -> Option<String> {
+    pub fn get_url_for(&self, station_name: &str) -> Option<String> {
         for s in self.data.iter() {
             if s.station.eq(station_name) {
                 return Some(s.url.clone());
@@ -152,45 +149,6 @@ impl Config {
         }
 
         stations
-    }
-
-    /// Prompts the user to select a station.
-    /// Returns a station and if the station was taken from the internet.
-    pub fn prompt(self) -> Result<(Station, bool), InquireError> {
-        let max_lines: usize = match self.max_lines {
-            Some(x) => x,
-            None => Select::<Station>::DEFAULT_PAGE_SIZE,
-        };
-
-        let res = Select::new(&"Select a station to play:".bold(), self.data.clone())
-            .with_page_size(max_lines)
-            .prompt();
-
-        let internet: bool;
-        let station: Station = match res {
-            Ok(s) => {
-                if s.station.eq("Other") {
-                    internet = true;
-                    let result = Browser::new(self);
-
-                    let brow = match result {
-                        Ok(b) => b,
-                        Err(_e) => return Err(InquireError::OperationInterrupted),
-                    };
-
-                    match brow.prompt() {
-                        Ok(r) => r,
-                        Err(e) => return Err(e),
-                    }
-                } else {
-                    internet = false;
-                    s
-                }
-            }
-            Err(e) => return Err(e),
-        };
-
-        Ok((station, internet))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         Err(error) => {
             debug!("{:?}", error);
             error!("{}", error);
-            info!("{}", "Try pasing the debug flag (-vvv). ".yellow());
+            info!("{}", "Try passing the debug flag (-vvv). ".yellow());
 
             info!(
                 "{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,9 @@ fn main() {
             None => {
                 let (station, internet, updated_cached_stations) =
                     get_station(station_arg, config.clone(), cached_stations.clone());
-                cached_stations = updated_cached_stations;
+                if !args.no_station_cache {
+                    cached_stations = updated_cached_stations;
+                }
 
                 print!("Playing {}", station.station.green());
 


### PR DESCRIPTION
This adds the planned feature from the README for looping back to the selection list after pressing q.

Additionally, I added a caching mechanism for the stations retrieved through the radio browser API. For me, this would be one of the main reasons why I even want to loop back to the selection list. Depending on the current internet speed, loading the station list might take a while. This cache can optionally be disabled using the new `--no-station-cache` flag (either to save memory or to force a reload).

If there's something you'd like to have differently, let me know. This is just the way that I would have done it.