### PR TITLE
Remove "80s 90s Super Pop Hits" from default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple radio CLI written in rust.
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
 ![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0) 
 
-_Note: Untested on MacOS, but it should work... Hell, it should even work on Android. Give it a try!_
+_Note: Hell, it should even work on Android. Give it a try!_
 
 ### Warning! (**DEPENDENCIES**)
 - *Needed*: `mpv` is called to play the audio/video. (See the [How it works](https://github.com/margual56/radio-cli#how-it-works) section).

--- a/config.json
+++ b/config.json
@@ -4,10 +4,6 @@
 	"country": "ES",
 	"data": [
 		{
-			"station": "80s 90s Super Pop Hits",
-			"url": "https://streaming.shoutcast.com/80s-90s-super"
-		},
-		{
 			"station": "lofi",
 			"url": "https://www.youtube.com/live/jfKfPfyJRdk?si=WDl-XdfuhxBfe6XN"
 		}


### PR DESCRIPTION
This station seems to be no longer available. I think having an unavailable station in the default config doesn't make much sense. Or did the station just move elsewhere?

Also, I removed the note about macOS. I'm using radio-cli on macOS for over a year now without any issues.

On another note: if you plan to do a release btw, maybe you can bump the dependencies to their latest version first (or at least the version of the libc crate). I wasn't able to verify it (yet), but that should allow the program to be built for loongarch64 as well and I don't have to exclude that architecture in the Alpine Linux package.